### PR TITLE
AddProperty doesn't work if you have `"`s in the string.

### DIFF
--- a/query/traversal/addproperty.go
+++ b/query/traversal/addproperty.go
@@ -47,7 +47,7 @@ func (g String) Property(objOrCard interface{}, obj interface{}, params ...inter
 
 	switch obj.(type) {
 	case string:
-		g = g.append(",\"" + obj.(string) + "\"")
+		g = g.append(",\"" + strings.ReplaceAll(obj.(string), "\"", "\\\"") + "\"")
 	default:
 		g = g.append(fmtStr(",%v", obj))
 	}
@@ -56,7 +56,7 @@ func (g String) Property(objOrCard interface{}, obj interface{}, params ...inter
 		for _, p := range params {
 			switch obj.(type) {
 			case string:
-				g = g.append(",\"" + p.(string) + "\"")
+				g = g.append(",\"" + strings.ReplaceAll(p.(string), "\"", "\\\"") + "\"")
 			default:
 				g = g.append(fmtStr(",%v", p))
 			}

--- a/query/traversal/addproperty.go
+++ b/query/traversal/addproperty.go
@@ -20,7 +20,11 @@
 
 package traversal
 
-import "github.com/northwesternmutual/grammes/query/cardinality"
+import (
+	"strings"
+	
+	"github.com/northwesternmutual/grammes/query/cardinality"
+)
 
 // http://tinkerpop.apache.org/docs/current/reference/#addproperty-step
 


### PR DESCRIPTION
The original lib causes an error while doing this:

```go
body := "{\"a\":\"b\"}"
vertex.AddProperty(client, "json", body)

# generated query is
# g.V().hasId("..").property("json", "{"a":"b"}")

# this patch, causes the generated query to be right:
# g.V().hasId("...").property("json", "{\"a\":\"b\"}")
```