### PR TITLE
Grammes add error context for connection failure

### DIFF
--- a/gremconnect/websocket.go
+++ b/gremconnect/websocket.go
@@ -77,9 +77,9 @@ func (ws *WebSocket) Connect() error {
 			defer httpResponse.Body.Close()
 
 			// Try to read the http response to add context to the error
-			readErr, errorOutput := ioutil.ReadAll(httpResponse.Body)
+			errorOutput, readErr := ioutil.ReadAll(httpResponse.Body)
 			if readErr != nil {
-				return fmt.Errorf("error connecting to address. response: %s. error %v", errorOutput, err)
+				return fmt.Errorf("error connecting to address. response: %s. error %v", string(errorOutput), err)
 			}
 		}
 

--- a/gremconnect/websocket.go
+++ b/gremconnect/websocket.go
@@ -78,7 +78,7 @@ func (ws *WebSocket) Connect() error {
 
 			// Try to read the http response to add context to the error
 			errorOutput, readErr := ioutil.ReadAll(httpResponse.Body)
-			if readErr != nil {
+			if readErr == nil {
 				return fmt.Errorf("error connecting to address. response: %s. error %v", string(errorOutput), err)
 			}
 		}


### PR DESCRIPTION
Currently, when a connection fails, only the "bad handshake" error is returned. the context (httpresponse) that is returned from the gorilla library is omitted. This helps to include that context into the error to have a clear view of what failed, when a connection fails.