### PR TITLE
Move from double quotes to single quote to reduce escaping

### DIFF
--- a/model/vertex_query.go
+++ b/model/vertex_query.go
@@ -140,7 +140,7 @@ func (v *Vertex) AddEdge(client queryClient, label string, outVID interface{}, p
 	}
 
 	var query = newTrav().V().HasID(v.ID()).AddE(label).To(newTrav().V().HasID(outVID).Raw())
-	// query := fmt.Sprintf("g.V().hasId(%v).addE(\"%s\").to(V().hasId(%v))", v.ID(), label, outVID)
+	// query := fmt.Sprintf("g.V().hasId(%v).addE('%s').to(V().hasId(%v))", v.ID(), label, outVID)
 
 	if len(properties)%2 != 0 {
 		return Edge{}, gremerror.NewGrammesError("AddEdge", gremerror.ErrOddNumberOfParameters)

--- a/query/graph/addvertex.go
+++ b/query/graph/addvertex.go
@@ -37,7 +37,7 @@ func (graph String) AddVertex(params ...interface{}) String {
 	switch params[0].(type) {
 	case string:
 		// custom property or other strings.
-		graph = graph.append("\"" + params[0].(string) + "\"")
+		graph = graph.append("'" + params[0].(string) + "'")
 	default:
 		// token or other types.
 		graph = graph.append(fmt.Sprintf("%v", params[0]))
@@ -48,7 +48,7 @@ func (graph String) AddVertex(params ...interface{}) String {
 			switch p.(type) {
 			case string:
 				// custom property or other strings.
-				graph = graph.append(",\"" + p.(string) + "\"")
+				graph = graph.append(",'" + p.(string) + "'")
 			default:
 				// Token or other types.
 				graph = graph.append(fmt.Sprintf(",%v", p))

--- a/query/graph/addvertex_test.go
+++ b/query/graph/addvertex_test.go
@@ -34,13 +34,13 @@ func TestAddVertex(t *testing.T) {
 		Convey("When 'AddVertex' is called with a Token and Label string", func() {
 			result := g.AddVertex(T.Label, "testinglabel")
 			Convey("Then result should equal 'graph.addVertex(T.label,'testinglabel')'", func() {
-				So(result.String(), ShouldEqual, "graph.addVertex(T.label,\"testinglabel\")")
+				So(result.String(), ShouldEqual, "graph.addVertex(T.label,'testinglabel')")
 			})
 		})
 		Convey("When 'AddVertex' is called with a string and a Token", func() {
 			result := g.AddVertex("teststring", "testval", T.Key)
 			Convey("Then result should equal 'graph.addVertex('teststring','testval',T.key)'", func() {
-				So(result.String(), ShouldEqual, "graph.addVertex(\"teststring\",\"testval\",T.key)")
+				So(result.String(), ShouldEqual, "graph.addVertex('teststring','testval',T.key)")
 			})
 		})
 		Convey("When 'AddVertex' is called with a Token, Label string, "+
@@ -48,7 +48,7 @@ func TestAddVertex(t *testing.T) {
 			result := g.AddVertex(T.Label, "testinglabel", "testkey", "testval")
 			Convey("Then result should equal "+
 				"'graph.addVertex(T.label,'testinglabel','testkey','testval')'", func() {
-				So(result.String(), ShouldEqual, "graph.addVertex(T.label,\"testinglabel\",\"testkey\",\"testval\")")
+				So(result.String(), ShouldEqual, "graph.addVertex(T.label,'testinglabel','testkey','testval')")
 			})
 		})
 	})

--- a/query/graph/makeedgelabel.go
+++ b/query/graph/makeedgelabel.go
@@ -22,7 +22,7 @@ package graph
 
 // MakeEdgeLabel create a label for a new edge.
 func (graph String) MakeEdgeLabel(label string) String {
-	graph = graph.append(".makeEdgeLabel(\"" + label + "\")")
+	graph = graph.append(".makeEdgeLabel('" + label + "')")
 
 	return graph
 }

--- a/query/graph/makeedgelabel_test.go
+++ b/query/graph/makeedgelabel_test.go
@@ -32,7 +32,7 @@ func TestMakeEdgeLabel(t *testing.T) {
 		Convey("When 'MakeEdgeLabel' is called with a label string", func() {
 			result := graph.MakeEdgeLabel("label")
 			Convey("Then result should equal 'graph.makeEdgeLabel('label')'", func() {
-				So(result.String(), ShouldEqual, "graph.makeEdgeLabel(\"label\")")
+				So(result.String(), ShouldEqual, "graph.makeEdgeLabel('label')")
 			})
 		})
 	})

--- a/query/graph/makepropertykey.go
+++ b/query/graph/makepropertykey.go
@@ -29,7 +29,7 @@ import (
 
 // MakePropertyKey create a label for a new edge.
 func (graph String) MakePropertyKey(label string, datatype datatype.DataType, cardinality cardinality.Cardinality) String {
-	graph = graph.append(".makePropertyKey(\"" + label + "\")")
+	graph = graph.append(".makePropertyKey('" + label + "')")
 	graph = graph.append(fmt.Sprintf(".dataType(%v).cardinality(%v)", datatype, cardinality))
 
 	return graph

--- a/query/graph/makepropertykey_test.go
+++ b/query/graph/makepropertykey_test.go
@@ -38,7 +38,7 @@ func TestMakePropertyKey(t *testing.T) {
 			var cr = cardinality.List
 			result := g.MakePropertyKey("labelTest", dt, cr)
 			Convey("Then result should equal 'graph.makePropertyKey('labelTest').dataType(String.class).cardinality(list)'", func() {
-				So(result.String(), ShouldEqual, "graph.makePropertyKey(\"labelTest\").dataType(String.class).cardinality(list)")
+				So(result.String(), ShouldEqual, "graph.makePropertyKey('labelTest').dataType(String.class).cardinality(list)")
 			})
 		})
 	})

--- a/query/graph/makevertexlabel.go
+++ b/query/graph/makevertexlabel.go
@@ -22,6 +22,6 @@ package graph
 
 // MakeVertexLabel will create a label for a vertex in the graph.
 func (graph String) MakeVertexLabel(name string) String {
-	graph = graph.append(".makeVertexLabel(\"" + name + "\")")
+	graph = graph.append(".makeVertexLabel('" + name + "')")
 	return graph
 }

--- a/query/graph/makevertexlabel_test.go
+++ b/query/graph/makevertexlabel_test.go
@@ -32,7 +32,7 @@ func TestMakeVertexLabel(t *testing.T) {
 		Convey("When 'MakeVertexLabel' is called with a name string", func() {
 			result := graph.MakeVertexLabel("name")
 			Convey("Then result should equal 'graph.makeVertexLabel('name')'", func() {
-				So(result.String(), ShouldEqual, "graph.makeVertexLabel(\"name\")")
+				So(result.String(), ShouldEqual, "graph.makeVertexLabel('name')")
 			})
 		})
 	})

--- a/query/predicate/comparepredicate.go
+++ b/query/predicate/comparepredicate.go
@@ -89,7 +89,7 @@ func Within(params ...interface{}) *Predicate {
 		buffer.WriteString(sep)
 		switch t := p.(type) {
 		case string:
-			buffer.WriteString("\"" + t + "\"")
+			buffer.WriteString("'" + t + "'")
 		default:
 			buffer.WriteString(fmt.Sprintf("%v", t))
 		}

--- a/query/traversal/addedge.go
+++ b/query/traversal/addedge.go
@@ -32,7 +32,7 @@ func (g String) AddE(param interface{}) String {
 	case String:
 		g = g.append(".addE(" + param.(String).Raw().String() + ")")
 	case string:
-		g = g.append(".addE(\"" + param.(string) + "\")")
+		g = g.append(".addE('" + param.(string) + "')")
 	default:
 		g.AddStep("addE")
 	}

--- a/query/traversal/addedge_test.go
+++ b/query/traversal/addedge_test.go
@@ -31,14 +31,14 @@ func TestAddE(t *testing.T) {
 		g := NewTraversal()
 		Convey("When 'AddE' is called with a traversal string", func() {
 			res := g.AddE(NewTraversal().Label())
-			Convey("Then the graph traversal should be 'g.addE(\"test\")'", func() {
+			Convey("Then the graph traversal should be 'g.addE('test')'", func() {
 				So(res.String(), ShouldEqual, "g.addE(label())")
 			})
 		})
 		Convey("When 'AddE' is called with a string", func() {
 			res := g.AddE("somethingelse")
-			Convey("Then the graph traversal should be 'g.addE(\"somethingelse\")'", func() {
-				So(res.String(), ShouldEqual, "g.addE(\"somethingelse\")")
+			Convey("Then the graph traversal should be 'g.addE('somethingelse')'", func() {
+				So(res.String(), ShouldEqual, "g.addE('somethingelse')")
 			})
 		})
 		Convey("When 'AddE' is called with anything else", func() {

--- a/query/traversal/addproperty_test.go
+++ b/query/traversal/addproperty_test.go
@@ -33,13 +33,13 @@ func TestProperty(t *testing.T) {
 		Convey("When 'Property' is called with object strings", func() {
 			result := g.Property("obj1", "obj2", "obj3", "obj4")
 			Convey("Then result should equal 'g.property('obj1','obj2','obj3','obj4')", func() {
-				So(result.String(), ShouldEqual, "g.property(\"obj1\",\"obj2\",\"obj3\",\"obj4\")")
+				So(result.String(), ShouldEqual, "g.property('obj1','obj2','obj3','obj4')")
 			})
 		})
 		Convey("When 'Property' is called with object strings and cardinality", func() {
 			result := g.Property(cardinality.Set, "obj1", "obj2")
 			Convey("Then result should equal 'g.property(set,'obj1','obj2')'", func() {
-				So(result.String(), ShouldEqual, "g.property(set,\"obj1\",\"obj2\")")
+				So(result.String(), ShouldEqual, "g.property(set,'obj1','obj2')")
 			})
 		})
 		Convey("When 'Property' is called with object strings and ints", func() {

--- a/query/traversal/addvertex_test.go
+++ b/query/traversal/addvertex_test.go
@@ -32,7 +32,7 @@ func TestAddV(t *testing.T) {
 		Convey("When 'AddV' is called with a string", func() {
 			result := g.AddV("myVertex")
 			Convey("Then result should equal 'g.addV('myVertex')'", func() {
-				So(result.String(), ShouldEqual, "g.addV(\"myVertex\")")
+				So(result.String(), ShouldEqual, "g.addV('myVertex')")
 			})
 		})
 

--- a/query/traversal/aggregate.go
+++ b/query/traversal/aggregate.go
@@ -30,7 +30,7 @@ package traversal
 // Signatures:
 // Aggregate(string)
 func (g String) Aggregate(str string) String {
-	g = g.append(".aggregate(\"" + str + "\")")
+	g = g.append(".aggregate('" + str + "')")
 
 	return g
 }

--- a/query/traversal/aggregate_test.go
+++ b/query/traversal/aggregate_test.go
@@ -32,7 +32,7 @@ func TestAggregate(t *testing.T) {
 		Convey("When 'Aggregate' is called with a string", func() {
 			result := g.Aggregate("test")
 			Convey("Then result should equal 'g.aggregate('test')'", func() {
-				So(result.String(), ShouldEqual, "g.aggregate(\"test\")")
+				So(result.String(), ShouldEqual, "g.aggregate('test')")
 			})
 		})
 	})

--- a/query/traversal/as.go
+++ b/query/traversal/as.go
@@ -38,12 +38,12 @@ func (g String) As(labels ...string) String {
 	}
 
 	if len(labels) > 0 {
-		g = g.append("\"" + labels[0] + "\"")
+		g = g.append("'" + labels[0] + "'")
 	}
 
 	if len(labels) > 1 {
 		for _, v := range labels[1:] {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 

--- a/query/traversal/as_test.go
+++ b/query/traversal/as_test.go
@@ -32,7 +32,7 @@ func TestAs(t *testing.T) {
 		Convey("When 'As' is called with multiple strings", func() {
 			result := g.As("test1", "test2")
 			Convey("Then result should equal 'g.as('test1','test2')'", func() {
-				So(result.String(), ShouldEqual, "g.as(\"test1\",\"test2\")")
+				So(result.String(), ShouldEqual, "g.as('test1','test2')")
 			})
 		})
 

--- a/query/traversal/both.go
+++ b/query/traversal/both.go
@@ -25,11 +25,11 @@ func (g String) Both(labels ...string) String {
 	g = g.append(".both(")
 
 	if len(labels) > 0 {
-		g = g.append("\"" + labels[0] + "\"")
+		g = g.append("'" + labels[0] + "'")
 
 		if len(labels) > 1 {
 			for _, v := range labels[1:] {
-				g = g.append(",\"" + v + "\"")
+				g = g.append(",'" + v + "'")
 			}
 		}
 	}
@@ -44,11 +44,11 @@ func (g String) BothE(labels ...string) String {
 	g = g.append(".bothE(")
 
 	if len(labels) > 0 {
-		g = g.append("\"" + labels[0] + "\"")
+		g = g.append("'" + labels[0] + "'")
 
 		if len(labels) > 1 {
 			for _, v := range labels[1:] {
-				g = g.append(",\"" + v + "\"")
+				g = g.append(",'" + v + "'")
 			}
 		}
 	}

--- a/query/traversal/both_test.go
+++ b/query/traversal/both_test.go
@@ -12,7 +12,7 @@ func TestBoth(t *testing.T) {
 		Convey("When 'Both' is called with an multiple parametrs", func() {
 			result := g.Both("lblTest1", "lblTest2")
 			Convey("Then result should equal 'g.both('lblTest1','lblTest2')'", func() {
-				So(result.String(), ShouldEqual, "g.both(\"lblTest1\",\"lblTest2\")")
+				So(result.String(), ShouldEqual, "g.both('lblTest1','lblTest2')")
 			})
 		})
 	})
@@ -24,7 +24,7 @@ func TestBothE(t *testing.T) {
 		Convey("When 'BothE' is called with an multiple parametrs", func() {
 			result := g.BothE("lblTest1", "lblTest2")
 			Convey("Then result should equal 'g.bothE('lblTest1','lblTest2')'", func() {
-				So(result.String(), ShouldEqual, "g.bothE(\"lblTest1\",\"lblTest2\")")
+				So(result.String(), ShouldEqual, "g.bothE('lblTest1','lblTest2')")
 			})
 		})
 	})

--- a/query/traversal/by_test.go
+++ b/query/traversal/by_test.go
@@ -32,14 +32,14 @@ func TestBy(t *testing.T) {
 		Convey("When 'By' is called with multiple strings", func() {
 			result := g.By("test1", "test2", "test3")
 			Convey("Then result should equal 'g.by('test1','test2','test3')'", func() {
-				So(result.String(), ShouldEqual, "g.by(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.by('test1','test2','test3')")
 			})
 		})
 
 		Convey("When 'By' is called with one string", func() {
 			result := g.By("test")
 			Convey("Then result should equal 'g.by('test')'", func() {
-				So(result.String(), ShouldEqual, "g.by(\"test\")")
+				So(result.String(), ShouldEqual, "g.by('test')")
 			})
 		})
 
@@ -49,10 +49,10 @@ func TestBy(t *testing.T) {
 				So(result.String(), ShouldEqual, "g.by()")
 			})
 		})
-		Convey("When 'By' is called with order().by(\"id\", desc)", func() {
+		Convey("When 'By' is called with order().by('id', desc)", func() {
 			result := g.By("id", Custom("desc"))
-			Convey("Then result should equal 'g.by(\"id\",desc)'", func() {
-				So(result.String(), ShouldEqual, "g.by(\"id\",desc)")
+			Convey("Then result should equal 'g.by('id',desc)'", func() {
+				So(result.String(), ShouldEqual, "g.by('id',desc)")
 			})
 		})
 	})

--- a/query/traversal/cap.go
+++ b/query/traversal/cap.go
@@ -28,11 +28,11 @@ package traversal
 // Signatures:
 // Cap(string, ...string)
 func (g String) Cap(str string, optStrings ...string) String {
-	g = g.append(".cap(\"" + str + "\"")
+	g = g.append(".cap('" + str + "'")
 
 	if len(optStrings) > 0 {
 		for _, v := range optStrings {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 

--- a/query/traversal/cap_test.go
+++ b/query/traversal/cap_test.go
@@ -32,14 +32,14 @@ func TestCap(t *testing.T) {
 		Convey("When 'Cap' is called with optStrings = nil", func() {
 			result := g.Cap("test1")
 			Convey("Then result should equal 'g.cap('test1')'", func() {
-				So(result.String(), ShouldEqual, "g.cap(\"test1\")")
+				So(result.String(), ShouldEqual, "g.cap('test1')")
 			})
 		})
 
 		Convey("When 'Cap' is called with multiple strings", func() {
 			result := g.Cap("test1", "test2", "test3")
 			Convey("Then result should equal 'g.cap('test1','test2','test3')'", func() {
-				So(result.String(), ShouldEqual, "g.cap(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.cap('test1','test2','test3')")
 			})
 		})
 	})

--- a/query/traversal/dedup.go
+++ b/query/traversal/dedup.go
@@ -32,7 +32,7 @@ func (g String) Dedup(params ...interface{}) String {
 	// if len(params) > 0 {
 	// 	switch params[0].(type) {
 	// 	case string:
-	// 		g = g.append("\"" + params[0].(string) + "\"")
+	// 		g = g.append("'" + params[0].(string) + "'")
 	// 	case scope.Scope:
 	// 		g = g.append(params[0].(scope.Scope).String())
 	// 	default:
@@ -42,7 +42,7 @@ func (g String) Dedup(params ...interface{}) String {
 
 	// if len(params) > 1 {
 	// 	for _, v := range params[1:] {
-	// 		g = g.append(",\"" + v.(string) + "\"")
+	// 		g = g.append(",'" + v.(string) + "'")
 	// 	}
 	// }
 

--- a/query/traversal/dedup_test.go
+++ b/query/traversal/dedup_test.go
@@ -33,14 +33,14 @@ func TestDedup(t *testing.T) {
 		Convey("When 'Dedup' is called with object strings", func() {
 			result := g.Dedup("obj1", "obj2", "obj3")
 			Convey("Then result should equal 'g.dedup(obj1,obj2,obj3,obj4)'", func() {
-				So(result.String(), ShouldEqual, "g.dedup(\"obj1\",\"obj2\",\"obj3\")")
+				So(result.String(), ShouldEqual, "g.dedup('obj1','obj2','obj3')")
 			})
 		})
 
 		Convey("When 'Dedup' is called with interface", func() {
 			result := g.Dedup(scope.Global, "obj")
 			Convey("Then result should equal 'g.dedup(global,'obj')'", func() {
-				So(result.String(), ShouldEqual, "g.dedup(global,\"obj\")")
+				So(result.String(), ShouldEqual, "g.dedup(global,'obj')")
 			})
 		})
 

--- a/query/traversal/fold_test.go
+++ b/query/traversal/fold_test.go
@@ -32,7 +32,7 @@ func TestFold(t *testing.T) {
 		Convey("When 'Fold' is called with a string", func() {
 			result := g.Fold("foldTest")
 			Convey("Then result should equal 'g.fold('foldTest')'", func() {
-				So(result.String(), ShouldEqual, "g.fold(\"foldTest\")")
+				So(result.String(), ShouldEqual, "g.fold('foldTest')")
 			})
 		})
 

--- a/query/traversal/from_test.go
+++ b/query/traversal/from_test.go
@@ -32,7 +32,7 @@ func TestFrom(t *testing.T) {
 		Convey("When 'From' is called with a string", func() {
 			result := g.From("fromTest")
 			Convey("Then result should equal 'g.from(fromTest)'", func() {
-				So(result.String(), ShouldEqual, "g.from(\"fromTest\")")
+				So(result.String(), ShouldEqual, "g.from('fromTest')")
 			})
 		})
 

--- a/query/traversal/group_test.go
+++ b/query/traversal/group_test.go
@@ -33,7 +33,7 @@ func TestGroup(t *testing.T) {
 		Convey("When 'Group' is called with one string", func() {
 			result := g.Group("test")
 			Convey("Then result should equal 'g.group('test')'", func() {
-				So(result.String(), ShouldEqual, "g.group(\"test\")")
+				So(result.String(), ShouldEqual, "g.group('test')")
 			})
 		})
 

--- a/query/traversal/groupcount_test.go
+++ b/query/traversal/groupcount_test.go
@@ -33,7 +33,7 @@ func TestGroupCount(t *testing.T) {
 		Convey("When 'Group' is called with one string", func() {
 			result := g.GroupCount("test")
 			Convey("Then result should equal 'g.groupCount('test')'", func() {
-				So(result.String(), ShouldEqual, "g.groupCount(\"test\")")
+				So(result.String(), ShouldEqual, "g.groupCount('test')")
 			})
 		})
 

--- a/query/traversal/has.go
+++ b/query/traversal/has.go
@@ -81,14 +81,14 @@ func (g String) HasID(objOrP interface{}, objs ...string) String {
 func (g String) HasKey(pOrStr interface{}, handledStrings ...string) String {
 	switch pOrStr.(type) {
 	case string:
-		g = g.append(".hasKey(\"" + pOrStr.(string) + "\"")
+		g = g.append(".hasKey('" + pOrStr.(string) + "'")
 	default:
 		g = g.append(fmtStr(".hasKey(%v", pOrStr))
 	}
 
 	if len(handledStrings) > 0 {
 		for _, v := range handledStrings {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 
@@ -105,14 +105,14 @@ func (g String) HasKey(pOrStr interface{}, handledStrings ...string) String {
 func (g String) HasLabel(pOrStr interface{}, handledStrings ...string) String {
 	switch pOrStr.(type) {
 	case string:
-		g = g.append(".hasLabel(\"" + pOrStr.(string) + "\"")
+		g = g.append(".hasLabel('" + pOrStr.(string) + "'")
 	default:
 		g = g.append(fmtStr(".hasLabel(%v", pOrStr))
 	}
 
 	if len(handledStrings) > 0 {
 		for _, v := range handledStrings {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 
@@ -139,14 +139,14 @@ func (g String) HasNot(str string) String {
 func (g String) HasValue(objOrP interface{}, objs ...string) String {
 	switch objOrP.(type) {
 	case string:
-		g = g.append(".hasValue(\"" + objOrP.(string) + "\"")
+		g = g.append(".hasValue('" + objOrP.(string) + "'")
 	default:
 		g = g.append(fmtStr(".hasValue(%v)", objOrP))
 	}
 
 	if len(objs) > 0 {
 		for _, v := range objs {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 

--- a/query/traversal/has_test.go
+++ b/query/traversal/has_test.go
@@ -34,14 +34,14 @@ func TestHas(t *testing.T) {
 		Convey("When 'Has' is called with object strings", func() {
 			result := g.Has("obj1", "obj2", "obj3")
 			Convey("Then result should equal 'g.has('obj1','obj2','obj3')'", func() {
-				So(result.String(), ShouldEqual, "g.has(\"obj1\",\"obj2\",\"obj3\")")
+				So(result.String(), ShouldEqual, "g.has('obj1','obj2','obj3')")
 			})
 		})
 
 		Convey("When 'Has' is called with a traversal", func() {
 			result := g.Has("testHas", NewTraversal().Label().Raw())
 			Convey("Then result should equal 'g.has('testHas',label())'", func() {
-				So(result.String(), ShouldEqual, "g.has(\"testHas\",label())")
+				So(result.String(), ShouldEqual, "g.has('testHas',label())")
 			})
 		})
 
@@ -63,7 +63,7 @@ func TestHas(t *testing.T) {
 		Convey("When 'Has' is called with too many params", func() {
 			result := g.Has("first", "second", "third", "fourth")
 			Convey("Then result should equal 'g.has('first','second','third','fourth')'", func() {
-				So(result.String(), ShouldEqual, "g.has(\"first\",\"second\",\"third\",\"fourth\")")
+				So(result.String(), ShouldEqual, "g.has('first','second','third','fourth')")
 			})
 		})
 
@@ -72,7 +72,7 @@ func TestHas(t *testing.T) {
 			*p = "predicate"
 			result := g.Has("first", p, 1234)
 			Convey("Then result should equal 'g.has('first',predicate,1234')'", func() {
-				So(result.String(), ShouldEqual, "g.has(\"first\",predicate,1234)")
+				So(result.String(), ShouldEqual, "g.has('first',predicate,1234)")
 			})
 		})
 	})
@@ -84,14 +84,14 @@ func TestHasID(t *testing.T) {
 		Convey("When 'HasID' is called with one parameter", func() {
 			result := g.HasID("tstObjOrP")
 			Convey("Then result should equal 'g.hasId('tstObjOrP')'", func() {
-				So(result.String(), ShouldEqual, "g.hasId(\"tstObjOrP\")")
+				So(result.String(), ShouldEqual, "g.hasId('tstObjOrP')")
 			})
 		})
 
 		Convey("When 'HasID' is called with a multiple params", func() {
 			result := g.HasID("tstObjOrP", "tstObj1", "tstObj2")
 			Convey("Then result should equal 'g.hasId('tstObjOrP','tstObj1','tstObj2')'", func() {
-				So(result.String(), ShouldEqual, "g.hasId(\"tstObjOrP\",\"tstObj1\",\"tstObj2\")")
+				So(result.String(), ShouldEqual, "g.hasId('tstObjOrP','tstObj1','tstObj2')")
 			})
 		})
 	})
@@ -103,7 +103,7 @@ func TestHasKey(t *testing.T) {
 		Convey("When 'HasKey' is called with one parameter", func() {
 			result := g.HasKey("tstpOrStr")
 			Convey("Then result should equal 'g.hasKey('tstpOrStr')'", func() {
-				So(result.String(), ShouldEqual, "g.hasKey(\"tstpOrStr\")")
+				So(result.String(), ShouldEqual, "g.hasKey('tstpOrStr')")
 			})
 		})
 
@@ -117,7 +117,7 @@ func TestHasKey(t *testing.T) {
 		Convey("When 'HasKey' is called with a multiple params", func() {
 			result := g.HasKey("tstpOrStr", "tstHandled1", "tstHandled2")
 			Convey("Then result should equal 'g.hasKey('tstpOrStr','tstHandled1','tstHandled2')'", func() {
-				So(result.String(), ShouldEqual, "g.hasKey(\"tstpOrStr\",\"tstHandled1\",\"tstHandled2\")")
+				So(result.String(), ShouldEqual, "g.hasKey('tstpOrStr','tstHandled1','tstHandled2')")
 			})
 		})
 	})
@@ -129,14 +129,14 @@ func TestHasLabel(t *testing.T) {
 		Convey("When 'HasLabel' is called with one parameter", func() {
 			result := g.HasLabel("tstpOrStr")
 			Convey("Then result should equal 'g.hasLabel('tstpOrStr')'", func() {
-				So(result.String(), ShouldEqual, "g.hasLabel(\"tstpOrStr\")")
+				So(result.String(), ShouldEqual, "g.hasLabel('tstpOrStr')")
 			})
 		})
 
 		Convey("When 'HasLabel' is called with a multiple params", func() {
 			result := g.HasLabel("tstpOrStr", "tstHandled1", "tstHandled2")
 			Convey("Then result should equal 'g.hasLabel('tstpOrStr','tstHandled1','tstHandled2')'", func() {
-				So(result.String(), ShouldEqual, "g.hasLabel(\"tstpOrStr\",\"tstHandled1\",\"tstHandled2\")")
+				So(result.String(), ShouldEqual, "g.hasLabel('tstpOrStr','tstHandled1','tstHandled2')")
 			})
 		})
 
@@ -156,7 +156,7 @@ func TestHasNot(t *testing.T) {
 		Convey("When 'HasNot' is called", func() {
 			result := g.HasNot("testStr")
 			Convey("Then result should equal 'g.hasNot('testStr')'", func() {
-				So(result.String(), ShouldEqual, "g.hasNot(\"testStr\")")
+				So(result.String(), ShouldEqual, "g.hasNot('testStr')")
 			})
 		})
 	})
@@ -168,7 +168,7 @@ func TestHasValue(t *testing.T) {
 		Convey("When 'HasValue' is called with one parameter", func() {
 			result := g.HasValue("tstObjOrP")
 			Convey("Then result should equal 'g.hasValue('tstObjOrP')'", func() {
-				So(result.String(), ShouldEqual, "g.hasValue(\"tstObjOrP\")")
+				So(result.String(), ShouldEqual, "g.hasValue('tstObjOrP')")
 			})
 		})
 
@@ -182,7 +182,7 @@ func TestHasValue(t *testing.T) {
 		Convey("When 'HasValue' is called with a multiple params", func() {
 			result := g.HasValue("tstObjOrP", "tstObj1", "tstObj2")
 			Convey("Then result should equal 'g.hasValue('tstObjOrP','tstObj1','tstObj2')'", func() {
-				So(result.String(), ShouldEqual, "g.hasValue(\"tstObjOrP\",\"tstObj1\",\"tstObj2\")")
+				So(result.String(), ShouldEqual, "g.hasValue('tstObjOrP','tstObj1','tstObj2')")
 			})
 		})
 	})

--- a/query/traversal/in.go
+++ b/query/traversal/in.go
@@ -25,11 +25,11 @@ func (g String) In(labels ...string) String {
 	g = g.append(".in(")
 
 	if len(labels) > 0 {
-		g = g.append("\"" + labels[0] + "\"")
+		g = g.append("'" + labels[0] + "'")
 
 		if len(labels) > 1 {
 			for _, v := range labels[1:] {
-				g = g.append(",\"" + v + "\"")
+				g = g.append(",'" + v + "'")
 			}
 		}
 	}
@@ -44,11 +44,11 @@ func (g String) InE(labels ...string) String {
 	g = g.append(".inE(")
 
 	if len(labels) > 0 {
-		g = g.append("\"" + labels[0] + "\"")
+		g = g.append("'" + labels[0] + "'")
 
 		if len(labels) > 1 {
 			for _, v := range labels[1:] {
-				g = g.append(",\"" + v + "\"")
+				g = g.append(",'" + v + "'")
 			}
 		}
 	}

--- a/query/traversal/in_test.go
+++ b/query/traversal/in_test.go
@@ -12,7 +12,7 @@ func TestIn(t *testing.T) {
 		Convey("When 'In' is called with an multiple parametrs", func() {
 			result := g.In("lblTest1", "lblTest2")
 			Convey("Then result should equal 'g.in('lblTest1','lblTest2')'", func() {
-				So(result.String(), ShouldEqual, "g.in(\"lblTest1\",\"lblTest2\")")
+				So(result.String(), ShouldEqual, "g.in('lblTest1','lblTest2')")
 			})
 		})
 	})
@@ -24,7 +24,7 @@ func TestInE(t *testing.T) {
 		Convey("When 'InE' is called with an multiple parametrs", func() {
 			result := g.InE("lblTest1", "lblTest2")
 			Convey("Then result should equal 'g.inE('lblTest1','lblTest2')'", func() {
-				So(result.String(), ShouldEqual, "g.inE(\"lblTest1\",\"lblTest2\")")
+				So(result.String(), ShouldEqual, "g.inE('lblTest1','lblTest2')")
 			})
 		})
 	})

--- a/query/traversal/inject_test.go
+++ b/query/traversal/inject_test.go
@@ -32,7 +32,7 @@ func TestInject(t *testing.T) {
 		Convey("When 'Inject' is called", func() {
 			result := g.Inject("testStr")
 			Convey("Then result should equal 'g.inject()'", func() {
-				So(result.String(), ShouldEqual, "g.inject(\"testStr\")")
+				So(result.String(), ShouldEqual, "g.inject('testStr')")
 			})
 		})
 	})

--- a/query/traversal/is_test.go
+++ b/query/traversal/is_test.go
@@ -32,7 +32,7 @@ func TestIs(t *testing.T) {
 		Convey("When 'Is' is called", func() {
 			result := g.Is("testStr")
 			Convey("Then result should equal 'g.is()'", func() {
-				So(result.String(), ShouldEqual, "g.is(\"testStr\")")
+				So(result.String(), ShouldEqual, "g.is('testStr')")
 			})
 		})
 	})

--- a/query/traversal/limit_test.go
+++ b/query/traversal/limit_test.go
@@ -40,7 +40,7 @@ func TestLimit(t *testing.T) {
 
 		Convey("When 'Limit' is called with no params", func() {
 			result := g.Limit()
-			Convey("Then result should equal 'g.limit(\"", func() {
+			Convey("Then result should equal 'g.limit('", func() {
 				So(result.String(), ShouldEqual, "g.limit()")
 			})
 		})

--- a/query/traversal/math_test.go
+++ b/query/traversal/math_test.go
@@ -31,8 +31,8 @@ func TestMath(t *testing.T) {
 		g := NewTraversal()
 		Convey("When 'Math' is called", func() {
 			result := g.Math("testStr")
-			Convey("Then result should equal 'g.math(\"testStr\")'", func() {
-				So(result.String(), ShouldEqual, "g.math(\"testStr\")")
+			Convey("Then result should equal 'g.math('testStr')'", func() {
+				So(result.String(), ShouldEqual, "g.math('testStr')")
 			})
 		})
 	})

--- a/query/traversal/option.go
+++ b/query/traversal/option.go
@@ -36,11 +36,11 @@ func (g String) Option(params ...string) String {
 		fmt.Println("Too many paramaters to call Option()")
 	}
 
-	g = g.append(".option(\"" + params[0] + "\"")
+	g = g.append(".option('" + params[0] + "'")
 
 	if len(params) > 1 {
 		for _, v := range params {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 

--- a/query/traversal/option_test.go
+++ b/query/traversal/option_test.go
@@ -32,7 +32,7 @@ func TestOption(t *testing.T) {
 		Convey("When 'Option' is called with object strings", func() {
 			result := g.Option("obj")
 			Convey("Then result should equal 'g.option(obj)'", func() {
-				So(result.String(), ShouldEqual, "g.option(\"obj\")")
+				So(result.String(), ShouldEqual, "g.option('obj')")
 			})
 		})
 
@@ -46,7 +46,7 @@ func TestOption(t *testing.T) {
 		Convey("When 'Option' is called with too many params params", func() {
 			result := g.Option("obj1", "obj2", "obj3")
 			Convey("Then result should equal 'g.option('obj1','obj1','obj2','obj3')'", func() {
-				So(result.String(), ShouldEqual, "g.option(\"obj1\",\"obj1\",\"obj2\",\"obj3\")")
+				So(result.String(), ShouldEqual, "g.option('obj1','obj1','obj2','obj3')")
 			})
 		})
 	})

--- a/query/traversal/out_test.go
+++ b/query/traversal/out_test.go
@@ -12,7 +12,7 @@ func TestOut(t *testing.T) {
 		Convey("When 'Out' is called with an multiple parametrs", func() {
 			result := g.Out("lblTest1", "lblTest2")
 			Convey("Then result should equal 'g.out('lblTest1','lblTest2')'", func() {
-				So(result.String(), ShouldEqual, "g.out(\"lblTest1\",\"lblTest2\")")
+				So(result.String(), ShouldEqual, "g.out('lblTest1','lblTest2')")
 			})
 		})
 	})
@@ -24,7 +24,7 @@ func TestOutE(t *testing.T) {
 		Convey("When 'OutE' is called with an multiple parametrs", func() {
 			result := g.OutE("lblTest1", "lblTest2")
 			Convey("Then result should equal 'g.outE('lblTest1','lblTest2')'", func() {
-				So(result.String(), ShouldEqual, "g.outE(\"lblTest1\",\"lblTest2\")")
+				So(result.String(), ShouldEqual, "g.outE('lblTest1','lblTest2')")
 			})
 		})
 	})

--- a/query/traversal/profile_test.go
+++ b/query/traversal/profile_test.go
@@ -38,8 +38,8 @@ func TestProfile(t *testing.T) {
 
 		Convey("When 'Profile' is called with one strings", func() {
 			result := g.Profile("obj1")
-			Convey("Then result should equal 'g.profile(\"obj1\")'", func() {
-				So(result.String(), ShouldEqual, "g.profile(\"obj1\")")
+			Convey("Then result should equal 'g.profile('obj1')'", func() {
+				So(result.String(), ShouldEqual, "g.profile('obj1')")
 			})
 		})
 

--- a/query/traversal/program_test.go
+++ b/query/traversal/program_test.go
@@ -32,7 +32,7 @@ func TestProgram(t *testing.T) {
 		Convey("When 'Program' is called", func() {
 			result := g.Program("vertexProgram")
 			Convey("Then result should equal 'g.program(vertexProgram)'", func() {
-				So(result.String(), ShouldEqual, "g.program(\"vertexProgram\")")
+				So(result.String(), ShouldEqual, "g.program('vertexProgram')")
 			})
 		})
 	})

--- a/query/traversal/project.go
+++ b/query/traversal/project.go
@@ -28,11 +28,11 @@ package traversal
 // Signatures:
 // Project(string, ...string)
 func (g String) Project(str string, extraStrings ...string) String {
-	g = g.append(".project(\"" + str + "\"")
+	g = g.append(".project('" + str + "'")
 
 	if len(extraStrings) > 0 {
 		for _, v := range extraStrings {
-			g = g.append(",\"" + v + "\"")
+			g = g.append(",'" + v + "'")
 		}
 	}
 

--- a/query/traversal/project_test.go
+++ b/query/traversal/project_test.go
@@ -32,14 +32,14 @@ func TestProject(t *testing.T) {
 		Convey("When 'Project' is called with optStrings = nil", func() {
 			result := g.Project("test1")
 			Convey("Then result should equal 'g.project('test1')'", func() {
-				So(result.String(), ShouldEqual, "g.project(\"test1\")")
+				So(result.String(), ShouldEqual, "g.project('test1')")
 			})
 		})
 
 		Convey("When 'Cap' is called with multiple strings", func() {
 			result := g.Project("test1", "test2", "test3")
 			Convey("Then result should equal 'g.project('test1','test2','test3')'", func() {
-				So(result.String(), ShouldEqual, "g.project(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.project('test1','test2','test3')")
 			})
 		})
 	})

--- a/query/traversal/properties.go
+++ b/query/traversal/properties.go
@@ -30,11 +30,11 @@ func (g String) Properties(str ...string) String {
 	if len(str) < 1 {
 		g.AddStep("properties")
 	} else {
-		g = g.append(".properties(\"" + str[0] + "\"")
+		g = g.append(".properties('" + str[0] + "'")
 
 		if len(str) > 1 {
 			for _, v := range str[1:] {
-				g = g.append(",\"" + v + "\"")
+				g = g.append(",'" + v + "'")
 			}
 		}
 

--- a/query/traversal/properties_test.go
+++ b/query/traversal/properties_test.go
@@ -40,7 +40,7 @@ func TestProperties(t *testing.T) {
 		Convey("When 'Properties' is called with multiple arguments", func() {
 			result := g.Properties("test1", "test2", "test3")
 			Convey("Then result should equal 'g.properties('test1','test2','test3')'", func() {
-				So(result.String(), ShouldEqual, "g.properties(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.properties('test1','test2','test3')")
 			})
 		})
 	})

--- a/query/traversal/propertymap.go
+++ b/query/traversal/propertymap.go
@@ -29,11 +29,11 @@ func (g String) PropertyMap(str ...string) String {
 	if len(str) < 1 {
 		g.AddStep("propertyMap")
 	} else {
-		g = g.append(".propertyMap(\"" + str[0] + "\"")
+		g = g.append(".propertyMap('" + str[0] + "'")
 
 		if len(str) > 1 {
 			for _, v := range str[1:] {
-				g = g.append(",\"" + v + "\"")
+				g = g.append(",'" + v + "'")
 			}
 		}
 

--- a/query/traversal/propertymap_test.go
+++ b/query/traversal/propertymap_test.go
@@ -40,7 +40,7 @@ func TestPropertyMap(t *testing.T) {
 		Convey("When 'Properties' is called with multiple arguments", func() {
 			result := g.PropertyMap("test1", "test2", "test3")
 			Convey("Then result should equal 'g.propertyMap('test1','test2','test3')'", func() {
-				So(result.String(), ShouldEqual, "g.propertyMap(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.propertyMap('test1','test2','test3')")
 			})
 		})
 	})

--- a/query/traversal/select_test.go
+++ b/query/traversal/select_test.go
@@ -34,8 +34,8 @@ func TestSelect(t *testing.T) {
 		g := NewTraversal()
 		Convey("When 'Select' is called with just first argument string", func() {
 			result := g.Select("testFirst")
-			Convey("Then result should equal 'g.select(\"testFirst\")'", func() {
-				So(result.String(), ShouldEqual, "g.select(\"testFirst\")")
+			Convey("Then result should equal 'g.select('testFirst')'", func() {
+				So(result.String(), ShouldEqual, "g.select('testFirst')")
 			})
 		})
 
@@ -63,14 +63,14 @@ func TestSelect(t *testing.T) {
 		Convey("When 'Select' is called with extras argument ) String {", func() {
 			result := g.Select("testSelect", NewTraversal().Label().Raw())
 			Convey("Then result should equal 'g.select(testSelect,label())'", func() {
-				So(result.String(), ShouldEqual, "g.select(\"testSelect\",label())")
+				So(result.String(), ShouldEqual, "g.select('testSelect',label())")
 			})
 		})
 
 		Convey("When 'Select' is called with extras argument multiple string", func() {
 			result := g.Select("testFirst", "testExtras1", "testExtras2")
 			Convey("Then result should equal 'g.select(testFirst,testExtras1,testExtras2)'", func() {
-				So(result.String(), ShouldEqual, "g.select(\"testFirst\",\"testExtras1\",\"testExtras2\")")
+				So(result.String(), ShouldEqual, "g.select('testFirst','testExtras1','testExtras2')")
 			})
 		})
 

--- a/query/traversal/store_test.go
+++ b/query/traversal/store_test.go
@@ -31,8 +31,8 @@ func TestStore(t *testing.T) {
 		g := NewTraversal()
 		Convey("When 'Store' is called", func() {
 			result := g.Store("testStore")
-			Convey("Then result should equal 'g.store(\"testStore\")'", func() {
-				So(result.String(), ShouldEqual, "g.store(\"testStore\")")
+			Convey("Then result should equal 'g.store('testStore')'", func() {
+				So(result.String(), ShouldEqual, "g.store('testStore')")
 			})
 		})
 	})

--- a/query/traversal/subgraph_test.go
+++ b/query/traversal/subgraph_test.go
@@ -32,7 +32,7 @@ func TestSubGraph(t *testing.T) {
 		Convey("When 'SubGraph' is called", func() {
 			result := g.SubGraph("testSubGraph")
 			Convey("Then result should equal 'g.subgraph(testSubGraph)'", func() {
-				So(result.String(), ShouldEqual, "g.subgraph(\"testSubGraph\")")
+				So(result.String(), ShouldEqual, "g.subgraph('testSubGraph')")
 			})
 		})
 	})

--- a/query/traversal/to.go
+++ b/query/traversal/to.go
@@ -67,7 +67,7 @@ func (g String) To(first interface{}, extraStrings ...string) String {
 // Signatures:
 // ToE(Direction, string)
 func (g String) ToE(dir direction.Direction, str string) String {
-	g = g.append(fmtStr(".toE(%v, \"%v\")", dir, str))
+	g = g.append(fmtStr(".toE(%v, '%v')", dir, str))
 
 	return g
 }

--- a/query/traversal/to_test.go
+++ b/query/traversal/to_test.go
@@ -78,7 +78,7 @@ func TestToE(t *testing.T) {
 			dir = "left"
 			result := g.ToE(dir, "testStr")
 			Convey("Then result should equal 'g.toE(left, 'testStr')'", func() {
-				So(result.String(), ShouldEqual, "g.toE(left, \"testStr\")")
+				So(result.String(), ShouldEqual, "g.toE(left, 'testStr')")
 			})
 		})
 	})

--- a/query/traversal/tree_test.go
+++ b/query/traversal/tree_test.go
@@ -38,8 +38,8 @@ func TestTree(t *testing.T) {
 
 		Convey("When 'Group' is called with multiple parameters", func() {
 			result := g.Tree("test1", "test2")
-			Convey("Then result should equal 'g.tree(\"test1\")'", func() {
-				So(result.String(), ShouldEqual, "g.tree(\"test1\")")
+			Convey("Then result should equal 'g.tree('test1')'", func() {
+				So(result.String(), ShouldEqual, "g.tree('test1')")
 			})
 		})
 	})

--- a/query/traversal/util.go
+++ b/query/traversal/util.go
@@ -87,7 +87,7 @@ func (g *String) AddStep(step string, params ...interface{}) {
 		case []byte:
 			g.buffer.Write(t)
 		case string:
-			g.buffer.WriteString("\"" + strings.ReplaceAll(t, "\"", "\\\"") + "\"")
+			g.buffer.WriteString("'" + t + "'")
 		default:
 			g.buffer.WriteString(fmt.Sprintf("%v", t))
 		}

--- a/query/traversal/valuemap.go
+++ b/query/traversal/valuemap.go
@@ -36,7 +36,7 @@ func (g String) ValueMap(boolOrStrings ...interface{}) String {
 	// append the command beginning along with the first parameter value.
 	switch boolOrStrings[0].(type) {
 	case string:
-		g = g.append(".valueMap(\"" + boolOrStrings[0].(string) + "\"")
+		g = g.append(".valueMap('" + boolOrStrings[0].(string) + "'")
 	default:
 		g = g.append(fmtStr(".valueMap(%v", boolOrStrings[0]))
 	}
@@ -44,7 +44,7 @@ func (g String) ValueMap(boolOrStrings ...interface{}) String {
 	// append the rest of the parameters
 	if len(boolOrStrings) > 1 {
 		for _, v := range boolOrStrings[1:] {
-			g = g.append(fmtStr(",\"%v\"", v))
+			g = g.append(fmtStr(",'%v'", v))
 		}
 	}
 

--- a/query/traversal/valuemap_test.go
+++ b/query/traversal/valuemap_test.go
@@ -40,7 +40,7 @@ func TestValueMap(t *testing.T) {
 		Convey("When 'ValueMap' is called with a multiple strings", func() {
 			result := g.ValueMap("test1", "test2", "test3")
 			Convey("Then result should equal 'g.valueMap('myVertex')'", func() {
-				So(result.String(), ShouldEqual, "g.valueMap(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.valueMap('test1','test2','test3')")
 			})
 		})
 

--- a/query/traversal/values.go
+++ b/query/traversal/values.go
@@ -35,11 +35,11 @@ func (g String) Values(strs ...string) String {
 
 	// g = g.append(".values(")
 
-	// g = g.append("\"" + params[0] + "\"")
+	// g = g.append("'" + params[0] + "'")
 
 	// if len(params) > 1 {
 	// 	for _, p := range params[1:] {
-	// 		g = g.append(",\"" + p + "\"")
+	// 		g = g.append(",'" + p + "'")
 	// 	}
 	// }
 

--- a/query/traversal/values_test.go
+++ b/query/traversal/values_test.go
@@ -40,14 +40,14 @@ func TestValues(t *testing.T) {
 		Convey("When 'Values' is called with a single argument", func() {
 			result := g.Values("test")
 			Convey("Then result should equal 'g.values('test')'", func() {
-				So(result.String(), ShouldEqual, "g.values(\"test\")")
+				So(result.String(), ShouldEqual, "g.values('test')")
 			})
 		})
 
 		Convey("When 'Values' is called with a multiple arguments", func() {
 			result := g.Values("test1", "test2", "test3")
 			Convey("Then result should equal 'g.values('myVertex')'", func() {
-				So(result.String(), ShouldEqual, "g.values(\"test1\",\"test2\",\"test3\")")
+				So(result.String(), ShouldEqual, "g.values('test1','test2','test3')")
 			})
 		})
 	})


### PR DESCRIPTION
Changed all double quotes in protocol to single quote. This reduces tons of escaping and makes everything much more readable.
When checking other tools like gremlin-console - they are also using single quotes, as it is supported by groovy.