### PR TITLE
Add Date and UUID datatypes

### DIFF
--- a/query/datatype/datatype.go
+++ b/query/datatype/datatype.go
@@ -57,8 +57,12 @@ const (
 	Decimal DataType = "Decimal.class"
 	// Precision represents the class for Precision
 	Precision DataType = "Precision.class"
+	// Date represents the class for Date
+	Date DataType = "Date.class"
 	// Geoshape represents the class for Geoshape
 	Geoshape DataType = "Geoshape.class"
+	// UUID represents the class for UUID
+	UUID DataType = "UUID.class"
 )
 
 func (d DataType) String() string {


### PR DESCRIPTION
`datatypes.go` is missing two types [available in JanusGraph](https://docs.janusgraph.org/basics/schema/), namely the `Date` and `UUID` types. I've added them in this PR.